### PR TITLE
fix：优化tooltip的显示和隐藏

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+.idea


### PR DESCRIPTION
1.优化tooltip的显示和隐藏判断
2.移除visibleCellHoverChange事件的监听和处理
3.添加监听onScroll，用于滚动时隐藏