### PR TITLE
feat: draw函数性能优化,减少重复执行带来的性能损耗

### DIFF
--- a/src/EVirtTable.ts
+++ b/src/EVirtTable.ts
@@ -41,6 +41,7 @@ export default class EVirtTable {
     private overlayer: Overlayer;
     private contextMenu: ContextMenu;
     private loading: Loading;
+    private animationFrameId: number|undefined = undefined;
     ctx: Context;
 
     constructor(target: HTMLDivElement, options: EVirtTableOptions) {
@@ -121,7 +122,10 @@ export default class EVirtTable {
         };
     }
     draw(ignoreOverlayer = false) {
-        requestAnimationFrame(() => {
+        if(this.animationFrameId) {
+            cancelAnimationFrame(this.animationFrameId);
+        }
+        this.animationFrameId = requestAnimationFrame(() => {
             const startTime = performance.now();
             this.header.update();
             this.footer.update();


### PR DESCRIPTION
场景：
在websocket推送数据更新表格数据的场景下，当切换浏览器tab到其他页面时，websocket还会一直推送数据，进而触发表格更新

问题：
当切回到表格所在页面时，会一次性触发很多次draw函数中的requestAnimationFrame，导致页面出现几秒的白屏。


